### PR TITLE
Add: Pull request template for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+\## Description
+
+
+
+Please include a summary of the changes and any related issue.
+
+
+
+Fixes # (issue)
+
+
+
+\## Type of change
+
+
+
+\- \[ ] Bug fix
+
+\- \[ ] New feature
+
+\- \[ ] Documentation update
+
+\- \[ ] Other (please describe):
+
+
+
+\## Checklist
+
+
+
+\- \[ ] I have read the contributing guidelines
+
+\- \[ ] My changes follow the code style of this project
+
+\- \[ ] I have added tests if needed
+
+\- \[ ] I have updated documentation where necessary
+
+
+


### PR DESCRIPTION
## Description

This pull request adds a default pull request template in the `.github` folder.  
The template helps contributors provide clear, consistent, and complete information when opening a PR.

## Why this is useful

- Encourages better PR documentation
- Helps maintainers review faster
- Reduces back-and-forth communication

## Type of change

- [x] Documentation (PR template only)

## Checklist

- [x] I have read the contributing guidelines
- [x] My changes follow the project’s code and contribution style
