### PR TITLE
refactor: improve Terms & Privacy line styling on signup page

### DIFF
--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -229,11 +229,31 @@ export function AuthForm() {
           </TabsContent>
         </Tabs>
       </CardContent>
-      <CardFooter className="text-xs text-center text-slate-500">
+      {/* <CardFooter className="text-xs text-center text-slate-500">
         By continuing, you agree to our{" "}
         <a href="#" className="text-teal-600 hover:underline">Terms of Service</a> and{" "}
         <a href="#" className="text-teal-600 hover:underline">Privacy Policy</a>.
+      </CardFooter> */}
+      
+      <CardFooter className="mt-6 text-sm text-center text-slate-500">
+        <p>
+          By continuing, you agree to our&nbsp;
+          <a
+            href="#"
+            className="text-teal-600 hover:text-teal-700 hover:underline transition-colors duration-200 font-medium"
+          >
+            Terms of Service
+          </a>
+          &nbsp;and&nbsp;
+          <a
+            href="#"
+            className="text-teal-600 hover:text-teal-700 hover:underline transition-colors duration-200 font-medium"
+          >
+            Privacy Policy
+          </a>.
+        </p>
       </CardFooter>
+
     </Card>
   )
 }


### PR DESCRIPTION
\### What’s Changed
- Replaced the existing "Terms of Service and Privacy Policy" line with a cleaner, modern design.
- Increased font size from `text-xs` to `text-sm` for better readability.
- Added `mt-6` spacing for improved layout.
- Enhanced link styles with hover effects (color darkening, underline, smooth transition).
- Wrapped text in a <p> tag for better semantics and structure.



Fixes #36 



\### Why This Change?
The previous line was visually unappealing due to very small text and lack of spacing. This update makes it look more professional, readable, and consistent with the overall UI.




