### PR TITLE
fix #97: removed process.exit(1) to save server crash during invalid DB connection fails

### DIFF
--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -254,9 +254,12 @@ export function AuthForm() {
         </Tabs>
       </CardContent>
       <CardFooter className="text-xs text-center text-slate-500">
-        By continuing, you agree to our{" "}
-        <a href="#" className="text-teal-600 hover:underline">Terms of Service</a> and{" "}
-        <a href="#" className="text-teal-600 hover:underline">Privacy Policy</a>.
+        <span>
+          By continuing, you agree to our{'\u00A0'}
+          <a href="#" className="text-teal-600 hover:underline">Terms of Service</a>
+          {'\u00A0'}and{'\u00A0'}
+          <a href="#" className="text-teal-600 hover:underline">Privacy Policy</a>.
+        </span>
       </CardFooter>
     </Card>
   )

--- a/lib/dbConnect.ts
+++ b/lib/dbConnect.ts
@@ -1,7 +1,7 @@
 import mongoose from "mongoose"
 
 type ConnectionObject = {
-    isConnected?: number
+  isConnected?: number
 };
 
 const connection: ConnectionObject = {};
@@ -15,7 +15,7 @@ async function dbConnect(): Promise<void> {
   }
 
   try {
-  
+
     const db = await mongoose.connect(process.env.MONGO_URL || '', {});
 
     connection.isConnected = db.connections[0].readyState;
@@ -24,7 +24,7 @@ async function dbConnect(): Promise<void> {
   } catch (error) {
     console.error('Database connection failed:', error);
 
-    process.exit(1);
+    throw error;
   }
 }
 


### PR DESCRIPTION

## Description

removed process.exit(1) from the dbConnect.ts file to save server from crashing during an invalid DB connection or if the connection to DB is not successfull



Fixes: #97 



## Type of change



- \[x] Bug fix



## Checklist



- \[x] I have read the contributing guidelines

- \[x] My changes follow the code style of this project

- \[x] I have added tests if needed

- \[x] I have updated documentation where necessary



