### PR TITLE
modified model selection in chat page

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -40,7 +40,6 @@ export default function ChatPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [selectedModel, setSelectedModel] = useState("llama3-8b-8192");
-  const [selectedModelName, setSelectedModelName] = useState("LLaMA 3 8B (Fast)");
   const [showprompts, setShowprompts] = useState(true);
   const [location, setlocation] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -144,6 +143,13 @@ export default function ChatPage() {
     []
   );
 
+  const selectedModelLabel = useMemo(
+  () =>
+    modelOptions.find((m) => m.value === selectedModel)?.label ??
+    "LLaMA 3 8B (Fast)",
+  [modelOptions, selectedModel]
+);
+
   useEffect(() => {
     setTimeout(() => {
       setIsLoading(false);
@@ -165,22 +171,20 @@ export default function ChatPage() {
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          className="fixed z-50 flex items-center justify-content-between gap-2 focus:outline-none focus:ring-0 text-black mt-1 ml-4 w-52"
+          aria-label="Select model"
+          className="fixed top-20 left-4 z-50 flex items-center justify-between gap-2 focus-visible:ring-2 focus-visible:ring-ring dark:text-slate-100 w-52"
         >
-          <span className="">{selectedModelName}</span>
+          <span className="">{selectedModelLabel}</span>
           <ChevronDown className="h-4 w-4 opacity-70" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-72 p-2  text-black rounded-xl shadow-lg ml-4">
+      <DropdownMenuContent align="end" className="w-72 p-2 rounded-xl shadow-lg dark:text-slate-100">
         <p className="px-2 pb-2 text-sm text-slate-400">Choose your model</p>
         {modelOptions.map((option) => (
           <DropdownMenuItem
             key={option.value}
-            onClick={() => {
-              setSelectedModel(option.value);
-              setSelectedModelName(option.label);
-              }
-            }
+            onClick={() => setSelectedModel(option.value)}
+            aria-checked={selectedModel === option.value}
             className="flex justify-between items-start py-2 px-2 rounded-lg cursor-pointer"
           >
             <div>
@@ -200,7 +204,7 @@ export default function ChatPage() {
 
 
         <div className="flex-1 overflow-hidden">
-          <ScrollArea className="h-full p-8 mt-6 sm:p-8 sm:mt-6 md:p-8 md:mt-6 lg:p-6 lg:mt-0">
+          <ScrollArea className="h-full p-8 pt-16">
             <div className="w-full max-w-2xl mx-auto space-y-4 pb-20">
               <AnimatePresence initial={false}>
                 {messages.map((message) => (

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -3,10 +3,15 @@
 import type React from "react";
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Send } from "lucide-react";
+import { Check, ChevronDown, Send } from "lucide-react";
 import { format } from "date-fns";
 import ReactMarkdown from "react-markdown";
-
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -35,6 +40,7 @@ export default function ChatPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [selectedModel, setSelectedModel] = useState("llama3-8b-8192");
+  const [selectedModelName, setSelectedModelName] = useState("LLaMA 3 8B (Fast)");
   const [showprompts, setShowprompts] = useState(true);
   const [location, setlocation] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -154,9 +160,47 @@ export default function ChatPage() {
         <ChatSidebar />
       </div> */}
 
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col ">
+      <DropdownMenu >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="fixed z-50 flex items-center justify-content-between gap-2 focus:outline-none focus:ring-0 text-black mt-1 ml-4 w-52"
+        >
+          <span className="">{selectedModelName}</span>
+          <ChevronDown className="h-4 w-4 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72 p-2  text-black rounded-xl shadow-lg ml-4">
+        <p className="px-2 pb-2 text-sm text-slate-400">Choose your model</p>
+        {modelOptions.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => {
+              setSelectedModel(option.value);
+              setSelectedModelName(option.label);
+              }
+            }
+            className="flex justify-between items-start py-2 px-2 rounded-lg cursor-pointer"
+          >
+            <div>
+              <p className="font-medium">{option.label}</p>
+              
+            </div>
+            {selectedModel === option.value && (
+              <Check className="h-4 w-4 text-teal-400" />
+            )}
+          </DropdownMenuItem>
+        ))}
+        
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+
+
+
         <div className="flex-1 overflow-hidden">
-          <ScrollArea className="h-full p-6 sm:p-8">
+          <ScrollArea className="h-full p-8 mt-6 sm:p-8 sm:mt-6 md:p-8 md:mt-6 lg:p-6 lg:mt-0">
             <div className="w-full max-w-2xl mx-auto space-y-4 pb-20">
               <AnimatePresence initial={false}>
                 {messages.map((message) => (
@@ -261,20 +305,6 @@ export default function ChatPage() {
             )}
           </div>
 
-          <div className="max-w-3xl mx-auto mb-2">
-            <select
-              value={selectedModel}
-              onChange={(e) => setSelectedModel(e.target.value)}
-              className="w-full p-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
-              disabled={isLoading}
-            >
-              {modelOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
 
           <form onSubmit={handleSend} className="max-w-3xl mx-auto flex gap-2">
             <Input


### PR DESCRIPTION
\## Description
The viewport for actual chat is just half the screen as the model selection and the default prompts take a lot of space. So by moving the model selection to below the logo inspired by Gemini we can make it look more professional.


Please include a summary of the changes and any related issue.
created dropdown for model selection.
made it responsive.



Fixes # (issue)
#94 


\## Type of change
<img width="1869" height="861" alt="image" src="https://github.com/user-attachments/assets/969cc803-d0aa-4a7f-bcef-9b417b7677a7" />
<img width="1896" height="852" alt="image" src="https://github.com/user-attachments/assets/3b6625e3-d64d-4f53-bc78-fde4b306c844" />
<img width="286" height="511" alt="image" src="https://github.com/user-attachments/assets/3f9fb8ef-875b-4912-80a8-2ef1035f200a" />




\- \[ ] Bug fix

\- \[yes ] New feature

\- \[ ] Documentation update

\- \[ ] Other (please describe):



\## Checklist



\- \[ yes] I have read the contributing guidelines

\- \[yes ] My changes follow the code style of this project

\- \[ ] I have added tests if needed

\- \[ ] I have updated documentation where necessary





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a dropdown model selector with friendly labels, a checkmark for the active model, and a chevron indicator.
- Refactor
  - Replaced native select controls with a unified dropdown and consolidated model selection state while preserving API behavior and defaults.
- Style
  - Adjusted layout, spacing, and scroll area to accommodate the new selector and improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->