### PR TITLE
Changed the Twitter Old Logo to X logo

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -26,7 +26,7 @@ export function Footer() {
                 className="text-slate-500 hover:text-teal-600 dark:text-slate-400 dark:hover:text-teal-400"
               >
                 <SiX className="h-5 w-5" />
-                <span className="sr-only">Twitter</span>
+                <span className="sr-only">X(formerly Twitter)</span>
               </Link>
               <Link
                 href="#"

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Facebook, Twitter, Instagram, Linkedin } from "lucide-react"
+import { SiX, SiFacebook, SiInstagram, SiLinkedin } from "react-icons/si";
 
 export function Footer() {
   return (
@@ -18,28 +18,28 @@ export function Footer() {
                 href="#"
                 className="text-slate-500 hover:text-teal-600 dark:text-slate-400 dark:hover:text-teal-400"
               >
-                <Facebook className="h-5 w-5" />
+                <SiFacebook className="h-5 w-5" />
                 <span className="sr-only">Facebook</span>
               </Link>
               <Link
                 href="#"
                 className="text-slate-500 hover:text-teal-600 dark:text-slate-400 dark:hover:text-teal-400"
               >
-                <Twitter className="h-5 w-5" />
+                <SiX className="h-5 w-5" />
                 <span className="sr-only">Twitter</span>
               </Link>
               <Link
                 href="#"
                 className="text-slate-500 hover:text-teal-600 dark:text-slate-400 dark:hover:text-teal-400"
               >
-                <Instagram className="h-5 w-5" />
+                <SiInstagram className="h-5 w-5" />
                 <span className="sr-only">Instagram</span>
               </Link>
               <Link
                 href="#"
                 className="text-slate-500 hover:text-teal-600 dark:text-slate-400 dark:hover:text-teal-400"
               >
-                <Linkedin className="h-5 w-5" />
+                <SiLinkedin className="h-5 w-5" />
                 <span className="sr-only">LinkedIn</span>
               </Link>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "legal-ease",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@emotion/is-prop-valid": "latest",
         "@hookform/resolvers": "^3.9.1",
@@ -71,6 +72,8 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.1",
         "react-hot-toast": "^2.5.2",
+        "react-icon": "^1.0.0",
+        "react-icons": "^5.5.0",
         "react-markdown": "latest",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
@@ -85,7 +88,7 @@
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.21",
         "@types/express-session": "^1.17.7",
-        "@types/node": "^22.14.1",
+        "@types/node": "^22.18.1",
         "@types/pdfjs-dist": "^2.10.377",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3429,9 +3432,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3857,6 +3860,16 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/babel-runtime": {
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+      "integrity": "sha512-KpgoA8VE/pMmNCrnEeeXqFG24TIH11Z3ZaimIhJWsin8EbfZy3WzFKUTIan10ZIDgRVvi9EkLbruJElJC9dRlg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-js": "^1.0.0"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -4537,6 +4550,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -8273,6 +8294,25 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-icon": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-icon/-/react-icon-1.0.0.tgz",
+      "integrity": "sha512-VzSlpBHnLanVw79mOxyq98hWDi6DlxK9qPiZ1bAK6bLurMBCaxO/jjyYUrRx9+JGLc/NbnwOmyE/W5Qglbb2QA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-runtime": "^5.3.3",
+        "react": ">=0.12.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "patch-package" 
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",
@@ -73,6 +73,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.1",
     "react-hot-toast": "^2.5.2",
+    "react-icon": "^1.0.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "latest",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
@@ -87,7 +89,7 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.21",
     "@types/express-session": "^1.17.7",
-    "@types/node": "^22.14.1",
+    "@types/node": "^22.18.1",
     "@types/pdfjs-dist": "^2.10.377",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.1",
     "react-hot-toast": "^2.5.2",
-    "react-icon": "^1.0.0",
     "react-icons": "^5.5.0",
     "react-markdown": "latest",
     "react-resizable-panels": "^2.1.7",


### PR DESCRIPTION
\## Description
This PR updates the social media icons in the website footer to use the official brand logos instead of deprecated icons from lucide-react.

Changes include:

Replaced deprecated Lucide brand icons (Twitter, Facebook, Instagram, LinkedIn) with icons from react-icons/si (Simple Icons).
Updated X icon to use the official X (formerly Twitter) logo instead of the generic “cross” icon.
Ensured all icons are consistent in size (h-5 w-5) and support light/dark mode styling.

Fixes #114 

\##ScreenShot
<img width="377" height="361" alt="Screenshot 2025-09-06 183133" src="https://github.com/user-attachments/assets/6d72bb0f-c5fc-4093-a665-74820caee80c" />



\## Type of change



\- \[ ] Bug fix

\- \[ ] New feature

\- \[ ] Documentation update

\- \[ ] Other (please describe):



\## Checklist



\- \[ ] I have read the contributing guidelines

\- \[ ] My changes follow the code style of this project

\- \[ ] I have added tests if needed

\- \[ ] I have updated documentation where necessary





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Updated footer social icons to use a new icon set for a more modern, consistent look; adjusted the Twitter label to "X (formerly Twitter)". No link or navigation changes.
- Chores
  - Added the react-icons dependency and updated development typings.
  - Cleaned up minor formatting in the postinstall script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->